### PR TITLE
update tap-parser to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "dependencies": {
         "through": "~2.3.4",
-        "tap-parser": "~0.2.0"
+        "tap-parser": "~0.7.0"
     },
     "devDependencies": {
         "tap": "~0.4.6",


### PR DESCRIPTION
 fixes old browsers trailing commas bug: https://github.com/substack/tap-parser/commit/0bf06f59f3093baf11429887ab6d8b576ffff1f5

Thanks @substack