### PR TITLE
Fix when error is thrown

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var parser = require('tap-parser');
 var through = require('through');
+var once = require('once');
 
 module.exports = function (opts, cb) {
     if (typeof opts === 'function') {
@@ -8,6 +9,7 @@ module.exports = function (opts, cb) {
     }
     if (!opts) opts = {};
     if (opts.wait === undefined) opts.wait = 1000;
+    cb = once(cb);
     
     var p = parser();
     var seen = { plan: null, asserts: 0 };
@@ -26,10 +28,7 @@ module.exports = function (opts, cb) {
         check();
     });
     
-    p.on('results', function () {
-        if (finished) return;
-        finish();
-    });
+    p.on('results', cb);
     
     return p;
     

--- a/package.json
+++ b/package.json
@@ -1,42 +1,47 @@
 {
-    "name": "tap-finished",
-    "version": "0.0.1",
-    "description": "detect when tap output is finished",
-    "main": "index.js",
-    "dependencies": {
-        "through": "~2.3.4",
-        "tap-parser": "~0.2.0"
-    },
-    "devDependencies": {
-        "tap": "~0.4.6",
-        "tape": "~2.3.0"
-    },
-    "scripts": {
-        "test": "tap test/*.js"
-    },
-    "testling": {
-        "files": "test/*.js",
-        "browsers": [
-            "ie/8", "ie/9", "firefox/latest", "chrome/latest",
-            "safari/latest", "opera/latest"
-        ]
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/substack/tap-finished.git"
-    },
-    "homepage": "https://github.com/substack/tap-finished",
-    "keywords": [
-        "tap",
-        "parse",
-        "stream",
-        "complete",
-        "test"
-    ],
-    "author": {
-        "name": "James Halliday",
-        "email": "mail@substack.net",
-        "url": "http://substack.net"
-    },
-    "license": "MIT"
+  "name": "tap-finished",
+  "version": "0.0.1",
+  "description": "detect when tap output is finished",
+  "main": "index.js",
+  "dependencies": {
+    "once": "^1.3.3",
+    "tap-parser": "~0.2.0",
+    "through": "~2.3.4"
+  },
+  "devDependencies": {
+    "tap": "~0.4.6",
+    "tape": "~2.3.0"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "testling": {
+    "files": "test/*.js",
+    "browsers": [
+      "ie/8",
+      "ie/9",
+      "firefox/latest",
+      "chrome/latest",
+      "safari/latest",
+      "opera/latest"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/tap-finished.git"
+  },
+  "homepage": "https://github.com/substack/tap-finished",
+  "keywords": [
+    "tap",
+    "parse",
+    "stream",
+    "complete",
+    "test"
+  ],
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "license": "MIT"
 }

--- a/test/throw.js
+++ b/test/throw.js
@@ -1,0 +1,40 @@
+var test = require('tape');
+var finished = require('../');
+var lines = [
+    'TAP version 13',
+    '# throw',
+    'ok 1 (unnamed assert)',
+    'Error: hmm',
+    '    at Test.<anonymous> (http://localhost:51149/bundle.js:6:9)',
+    '    at Test.bound [as _cb] (http://localhost:51149/bundle.js:877:32)',
+    '    at Test.run (http://localhost:51149/bundle.js:893:10)',
+    '    at Test.bound [as run] (http://localhost:51149/bundle.js:877:32)',
+    '    at next (http://localhost:51149/bundle.js:1944:15)',
+    '    at http://localhost:51149/bundle.js:37:21'
+];
+
+test(function (t) {
+    t.plan(5);
+    var done = false;
+    
+    var stream = finished({ wait: 1000 }, function (results) {
+        t.equal(done, true);
+        
+        t.equal(results.pass.length, 1);
+        t.equal(results.pass[0].ok, true);
+        t.equal(results.fail.length, 0);
+        
+        t.notOk(results.ok);
+    });
+    
+    var iv = setInterval(function () {
+        if (lines.length === 0) {
+            clearInterval(iv);
+            done = true;
+            stream.end();
+        }
+        
+        var line = lines.shift();
+        stream.write(line + '\n');
+    }, 25);
+});


### PR DESCRIPTION
formerly this would never emit `"result"`, although the tap-parser does.